### PR TITLE
feat: add support for arbitrary startup args

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -8,16 +8,16 @@ impl AutoLaunch {
     /// Create a new AutoLaunch instance
     /// - `app_name`: application name
     /// - `app_path`: application path
-    /// - `hidden`: whether hidden the application on launch or not.
+    /// - `args`: startup args passed to the binary.
     ///
     /// ## Notes
     ///
     /// The parameters of `AutoLaunch::new` are different on each platform.
-    pub fn new(app_name: &str, app_path: &str, hidden: bool) -> AutoLaunch {
+    pub fn new(app_name: &str, app_path: &str, args: &[impl AsRef<str>]) -> AutoLaunch {
         AutoLaunch {
             app_name: app_name.into(),
             app_path: app_path.into(),
-            hidden,
+            args: args.iter().map(|s| s.as_ref().to_string()).collect(),
         }
     }
 
@@ -29,17 +29,19 @@ impl AutoLaunch {
     /// - failed to create file `~/.config/autostart/{app_name}.desktop`
     /// - failed to write bytes to the file
     pub fn enable(&self) -> Result<()> {
-        let hidden = if self.hidden { " --hidden" } else { "" };
         let data = format!(
             "[Desktop Entry]\n\
             Type=Application\n\
             Version=1.0\n\
             Name={}\n\
             Comment={}startup script\n\
-            Exec={}{}\n\
+            Exec={} {}\n\
             StartupNotify=false\n\
             Terminal=false",
-            self.app_name, self.app_name, self.app_path, hidden
+            self.app_name,
+            self.app_name,
+            self.app_path,
+            self.args.join(" ")
         );
 
         let dir = get_dir();

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -21,7 +21,12 @@ impl AutoLaunch {
     ///
     /// The `app_path` should be the **absolute path** and **exists**,
     ///     otherwise it will cause an error when `enable`.
-    pub fn new(app_name: &str, app_path: &str, use_launch_agent: bool, hidden: bool) -> AutoLaunch {
+    pub fn new(
+        app_name: &str,
+        app_path: &str,
+        use_launch_agent: bool,
+        args: &[impl AsRef<str>],
+    ) -> AutoLaunch {
         let mut name = app_name;
         if !use_launch_agent {
             // the app_name should be same as the executable's name
@@ -39,7 +44,7 @@ impl AutoLaunch {
             app_name: name.into(),
             app_path: app_path.into(),
             use_launch_agent,
-            hidden,
+            args: args.iter().map(|s| s.as_ref().to_string()).collect(),
         }
     }
 
@@ -71,11 +76,8 @@ impl AutoLaunch {
                 fs::create_dir(&dir)?;
             }
 
-            let mut args = vec![self.app_path.as_str()];
-
-            if self.hidden {
-                args.push("--hidden");
-            }
+            let mut args = vec![self.app_path.clone()];
+            args.extend_from_slice(&self.args);
 
             let section = args
                 .iter()

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -14,10 +14,11 @@ impl AutoLaunch {
     /// ## Notes
     ///
     /// The parameters of `AutoLaunch::new` are different on each platform.
-    pub fn new(app_name: &str, app_path: &str) -> AutoLaunch {
+    pub fn new(app_name: &str, app_path: &str, args: &[impl AsRef<str>]) -> AutoLaunch {
         AutoLaunch {
             app_name: app_name.into(),
             app_path: app_path.into(),
+            args: args.iter().map(|s| s.as_ref().to_string()).collect(),
         }
     }
 
@@ -30,7 +31,10 @@ impl AutoLaunch {
     pub fn enable(&self) -> Result<()> {
         let hkcu = RegKey::predef(HKEY_CURRENT_USER);
         hkcu.open_subkey_with_flags(AL_REGKEY, KEY_SET_VALUE)?
-            .set_value::<_, _>(&self.app_name, &self.app_path)
+            .set_value::<_, _>(
+                &self.app_name,
+                &format!("{} {}", &self.app_path, &self.args.join(" ")),
+            )
     }
 
     /// Disable the AutoLaunch setting

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -29,15 +29,17 @@ mod union_tests {
     fn test_macos_new() {
         let name_1 = "AutoLaunchTest"; // different name
         let name_2 = "auto-launch-test"; // same name
+
+        let args = &["--minimized"];
         let app_path = get_test_bin("auto-launch-test");
         let app_path = app_path.as_str();
 
         // applescript
-        let auto1 = AutoLaunch::new(name_1, app_path, false, false);
-        let auto2 = AutoLaunch::new(name_2, app_path, false, false);
+        let auto1 = AutoLaunch::new(name_1, app_path, false, args);
+        let auto2 = AutoLaunch::new(name_2, app_path, false, args);
         // launch agent
-        let auto3 = AutoLaunch::new(name_1, app_path, true, false);
-        let auto4 = AutoLaunch::new(name_2, app_path, true, false);
+        let auto3 = AutoLaunch::new(name_1, app_path, true, args);
+        let auto4 = AutoLaunch::new(name_2, app_path, true, args);
 
         // app_name will be revised
         assert_eq!(auto1.get_app_name(), name_2);
@@ -52,6 +54,7 @@ mod union_tests {
     fn test_macos_main() {
         let app_name = "auto-launch-test";
         let app_path = get_test_bin("auto-launch-test");
+        let args = &["--minimized"];
         let app_path = app_path.as_str();
 
         // path not exists
@@ -59,27 +62,27 @@ mod union_tests {
         let app_path_not = "/Applications/Calculator1.app";
 
         // use applescript
-        let auto1 = AutoLaunch::new(app_name, app_path, false, false);
+        let auto1 = AutoLaunch::new(app_name, app_path, false, args);
         assert_eq!(auto1.get_app_name(), app_name);
         assert!(auto1.enable().is_ok());
         assert!(auto1.is_enabled().unwrap());
         assert!(auto1.disable().is_ok());
         assert!(!auto1.is_enabled().unwrap());
 
-        let auto2 = AutoLaunch::new(app_name_not, app_path_not, false, false);
+        let auto2 = AutoLaunch::new(app_name_not, app_path_not, false, args);
         assert_eq!(auto2.get_app_name(), app_name_not);
         assert!(auto2.enable().is_err());
         assert!(!auto2.is_enabled().unwrap());
 
         // use launch agent
-        let auto1 = AutoLaunch::new(app_name, app_path, true, false);
+        let auto1 = AutoLaunch::new(app_name, app_path, true, args);
         assert_eq!(auto1.get_app_name(), app_name);
         assert!(auto1.enable().is_ok());
         assert!(auto1.is_enabled().unwrap());
         assert!(auto1.disable().is_ok());
         assert!(!auto1.is_enabled().unwrap());
 
-        let auto2 = AutoLaunch::new(app_name, app_path_not, true, false);
+        let auto2 = AutoLaunch::new(app_name, app_path_not, true, args);
         assert_eq!(auto2.get_app_name(), app_name); // will not change the name
         assert!(auto2.enable().is_err());
         assert!(!auto2.is_enabled().unwrap());
@@ -90,7 +93,7 @@ mod union_tests {
         let auto = AutoLaunchBuilder::new()
             .set_app_name(app_name)
             .set_app_path(app_path)
-            .set_hidden(true)
+            .set_args(args)
             .build();
 
         assert_eq!(auto.get_app_name(), app_name);
@@ -105,7 +108,7 @@ mod union_tests {
             .set_app_name(app_name)
             .set_app_path(app_path)
             .set_use_launch_agent(true)
-            .set_hidden(true)
+            .set_args(args)
             .build();
 
         assert_eq!(auto.get_app_name(), app_name);
@@ -121,10 +124,11 @@ mod union_tests {
     fn test_linux() {
         let app_name = "AutoLaunchTest";
         let app_path = get_test_bin("auto-launch-test");
+        let args = &["--minimized"];
         let app_path = app_path.as_str();
 
         // default test
-        let auto1 = AutoLaunch::new(app_name, app_path, false);
+        let auto1 = AutoLaunch::new(app_name, app_path, args);
 
         assert_eq!(auto1.get_app_name(), app_name);
         assert!(auto1.enable().is_ok());
@@ -132,8 +136,8 @@ mod union_tests {
         assert!(auto1.disable().is_ok());
         assert!(!auto1.is_enabled().unwrap());
 
-        // test hidden
-        let auto2 = AutoLaunch::new(app_name, app_path, true);
+        // test args
+        let auto2 = AutoLaunch::new(app_name, app_path, args);
 
         assert_eq!(auto2.get_app_name(), app_name);
         assert!(auto2.enable().is_ok());
@@ -147,9 +151,10 @@ mod union_tests {
     fn test_windows() {
         let app_name = "AutoLaunchTest";
         let app_path = get_test_bin("auto-launch-test");
+        let args = &["--minimized"];
         let app_path = app_path.as_str();
 
-        let auto = AutoLaunch::new(app_name, app_path);
+        let auto = AutoLaunch::new(app_name, app_path, args);
 
         assert_eq!(auto.get_app_name(), app_name);
         assert!(auto.enable().is_ok());
@@ -164,12 +169,13 @@ mod union_tests {
     fn test_builder() {
         let app_name = "auto-launch-test";
         let app_path = get_test_bin("auto-launch-test");
+        let args = &["--minimized"];
         let app_path = app_path.as_str();
 
         let auto = AutoLaunchBuilder::new()
             .set_app_name(app_name)
             .set_app_path(app_path)
-            .set_hidden(true)
+            .set_args(args)
             .build();
 
         #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
previously, the `hidden` option simply just passed `--hidden`
argument to the app on startup but that didn't guarantee
that the app will be hidden becaue the app itself needed to handle that
argument explicity so it is better to let the users pass arbitray
number of args to their app on startup and handle it as they see fit

BREAKING CHANGE: `hidden` option is removed and replaced with `args`
option to pass arbitrary number of args to the binary on startup