### PR TITLE
Handle auto launch being disabled in task manager (Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ fn main() {
 
 ### Windows
 
-On Windows, it will add a registry entry under `\HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Run`.
+On Windows, it will add registry entries under `\HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Run` and `\HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run`.
+
+It will also detect if startup is disabled inside Task Manager or the Windows settings UI, and can re-enable after being disabled in one of those.
 
 ```rust
 use auto_launch::AutoLaunch;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -10,6 +10,39 @@ mod unit_test {
     static TASK_MANAGER_OVERRIDE_REGKEY: &str =
         "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run";
 
+    const TASK_MANAGER_OVERRIDE_TEST_DATA: [(bool, [u8; 12]); 5] = [
+        (
+            false,
+            [
+                0x03, 0x00, 0x00, 0x00, 0xa5, 0x20, 0xf6, 0x4a, 0x95, 0xd7, 0xd9, 0x01,
+            ],
+        ),
+        (
+            false,
+            [
+                0x01, 0x00, 0x00, 0x00, 0x5c, 0x25, 0xea, 0xfd, 0xcc, 0xae, 0xd9, 0x01,
+            ],
+        ),
+        (
+            true,
+            [
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            ],
+        ),
+        (
+            true,
+            [
+                0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            ],
+        ),
+        (
+            true,
+            [
+                0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            ],
+        ),
+    ];
+
     fn get_test_bin(name: &str) -> String {
         let ext = match cfg!(target_os = "windows") {
             true => ".exe",
@@ -206,40 +239,7 @@ mod unit_test {
         assert!(auto.enable().is_ok());
         assert!(auto.is_enabled().unwrap());
 
-        const TEST_DATA: [(bool, [u8; 12]); 5] = [
-            (
-                false,
-                [
-                    0x03, 0x00, 0x00, 0x00, 0xa5, 0x20, 0xf6, 0x4a, 0x95, 0xd7, 0xd9, 0x01,
-                ],
-            ),
-            (
-                false,
-                [
-                    0x01, 0x00, 0x00, 0x00, 0x5c, 0x25, 0xea, 0xfd, 0xcc, 0xae, 0xd9, 0x01,
-                ],
-            ),
-            (
-                true,
-                [
-                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                ],
-            ),
-            (
-                true,
-                [
-                    0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                ],
-            ),
-            (
-                true,
-                [
-                    0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                ],
-            ),
-        ];
-
-        for (expected_enabled, value) in TEST_DATA {
+        for (expected_enabled, value) in TASK_MANAGER_OVERRIDE_TEST_DATA {
             set_task_manager_override_value(app_name, value);
             assert_eq!(
                 auto.is_enabled().unwrap(),
@@ -248,6 +248,26 @@ mod unit_test {
                 value
             );
         }
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_windows_can_enable_after_disabled_by_task_manager() {
+        let app_name = "AutoLaunchTest";
+        let app_path = get_test_bin("auto-launch-test");
+        let args = &["--minimized"];
+        let app_path = app_path.as_str();
+
+        let auto = AutoLaunch::new(app_name, app_path, args);
+
+        assert!(auto.enable().is_ok());
+        assert!(auto.is_enabled().unwrap());
+
+        set_task_manager_override_value(app_name, TASK_MANAGER_OVERRIDE_TEST_DATA[0].1);
+        assert!(!auto.is_enabled().unwrap());
+
+        assert!(auto.enable().is_ok());
+        assert!(auto.is_enabled().unwrap());
     }
 
     // There will be conflicts with other test cases on macos

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2,6 +2,13 @@
 mod unit_test {
     use auto_launch::{AutoLaunch, AutoLaunchBuilder};
     use std::env::current_dir;
+    use winreg::{
+        enums::{RegType, HKEY_CURRENT_USER, KEY_WRITE},
+        RegKey, RegValue,
+    };
+
+    static TASK_MANAGER_OVERRIDE_REGKEY: &str =
+        "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run";
 
     fn get_test_bin(name: &str) -> String {
         let ext = match cfg!(target_os = "windows") {
@@ -17,6 +24,26 @@ mod unit_test {
         // if not exists, check the test exe
         assert!(test_bin.exists());
         test_bin.as_os_str().to_string_lossy().into_owned()
+    }
+
+    fn set_task_manager_override_value(name: &str, value: [u8; 12]) {
+        let subkey = get_task_manager_override_subkey();
+        let reg_value = RegValue {
+            vtype: RegType::REG_BINARY,
+            bytes: value.to_vec(),
+        };
+        subkey.set_raw_value(name, &reg_value).unwrap();
+    }
+
+    fn delete_task_manager_override_value(name: &str) -> std::io::Result<()> {
+        let subkey = get_task_manager_override_subkey();
+        subkey.delete_value(name)
+    }
+
+    fn get_task_manager_override_subkey() -> RegKey {
+        RegKey::predef(HKEY_CURRENT_USER)
+            .open_subkey_with_flags(TASK_MANAGER_OVERRIDE_REGKEY, KEY_WRITE)
+            .unwrap()
     }
 
     #[test]
@@ -161,6 +188,66 @@ mod unit_test {
         assert!(auto.is_enabled().unwrap());
         assert!(auto.disable().is_ok());
         assert!(!auto.is_enabled().unwrap());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_windows_task_manager_overrides() {
+        let app_name = "AutoLaunchTest";
+        let app_path = get_test_bin("auto-launch-test");
+        let args = &["--minimized"];
+        let app_path = app_path.as_str();
+
+        let auto = AutoLaunch::new(app_name, app_path, args);
+
+        delete_task_manager_override_value(app_name).ok(); // Ensure previous test runs are cleaned up
+
+        assert_eq!(auto.get_app_name(), app_name);
+        assert!(auto.enable().is_ok());
+        assert!(auto.is_enabled().unwrap());
+
+        const TEST_DATA: [(bool, [u8; 12]); 5] = [
+            (
+                false,
+                [
+                    0x03, 0x00, 0x00, 0x00, 0xa5, 0x20, 0xf6, 0x4a, 0x95, 0xd7, 0xd9, 0x01,
+                ],
+            ),
+            (
+                false,
+                [
+                    0x01, 0x00, 0x00, 0x00, 0x5c, 0x25, 0xea, 0xfd, 0xcc, 0xae, 0xd9, 0x01,
+                ],
+            ),
+            (
+                true,
+                [
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                ],
+            ),
+            (
+                true,
+                [
+                    0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                ],
+            ),
+            (
+                true,
+                [
+                    0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                ],
+            ),
+        ];
+
+        for (expected_enabled, value) in TEST_DATA {
+            set_task_manager_override_value(app_name, value);
+            assert_eq!(
+                auto.is_enabled().unwrap(),
+                expected_enabled,
+                "{:02X?}",
+                value
+            );
+        }
     }
 
     // There will be conflicts with other test cases on macos


### PR DESCRIPTION
Addresses #7 by checking the registry keys set by Task Manager and analyzing the values there. Couldn't find anything definitive from Microsoft about the meaning of these values (of course), so the implementation is based on my testing and what others around the internet had found. It seems that while the first byte can have a couple different meaning, the last eight bytes are always 0s if enabled or some other value (probably a FILETIME) if disabled.

It also will set the reg key set by task manager when enabling to ensure that auto launch can be re-enabled after being disabled in task manager.

In my testing, I saw all of the values provided as test data for the test in my registry.

A couple references:
- https://community.spiceworks.com/topic/2346007-windows-10-task-manager-startup-disabled-items-registry-location
- https://superuser.com/questions/1766797/how-entries-at-run-registry-are-overridden-by-windows-settings
- https://superuser.com/questions/664641/where-are-disabled-autostart-programs-stored-somewhere-in-the-registry