### PR TITLE
feat: allow customize macos launch agent config

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,12 +199,12 @@ pub struct AutoLaunch {
     pub(crate) args: Vec<String>,
 
     #[cfg(target_os = "macos")]
-    /// Bundle identifiers
-    pub(crate) bundle_identifiers: Vec<String>,
-
-    #[cfg(target_os = "macos")]
     /// Whether use Launch Agent for implement or use AppleScript
     pub(crate) use_launch_agent: bool,
+
+    #[cfg(target_os = "macos")]
+    /// Bundle identifiers
+    pub(crate) bundle_identifiers: Vec<String>,
 
     #[cfg(target_os = "macos")]
     /// Extra config in plist file for Launch Agent

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,10 @@ pub struct AutoLaunch {
     /// Whether use Launch Agent for implement or use AppleScript
     pub(crate) use_launch_agent: bool,
 
+    #[cfg(target_os = "macos")]
+    /// Extra config in plist file for Launch Agent
+    pub(crate) agent_extra_config: String,
+
     #[cfg(windows)]
     pub(crate) enable_mode: WindowsEnableMode,
 }
@@ -276,6 +280,8 @@ pub struct AutoLaunchBuilder {
 
     pub use_launch_agent: bool,
 
+    pub agent_extra_config: Option<String>,
+
     pub windows_enable_mode: WindowsEnableMode,
 
     pub args: Option<Vec<String>>,
@@ -323,6 +329,13 @@ impl AutoLaunchBuilder {
         self
     }
 
+    /// Set the `agent_extra_config`
+    /// This setting only works on macOS
+    pub fn set_agent_extra_config(&mut self, config: &str) -> &mut Self {
+        self.agent_extra_config = Some(config.into());
+        self
+    }
+
     /// Set the [`WindowsEnableMode`].
     /// This setting only works on Windows
     pub fn set_windows_enable_mode(&mut self, mode: WindowsEnableMode) -> &mut Self {
@@ -347,6 +360,7 @@ impl AutoLaunchBuilder {
         let app_name = self.app_name.as_ref().ok_or(Error::AppNameNotSpecified)?;
         let app_path = self.app_path.as_ref().ok_or(Error::AppPathNotSpecified)?;
         let args = self.args.clone().unwrap_or_default();
+        let agent_extra_config = self.agent_extra_config.as_ref().map_or("", |v| v);
 
         #[cfg(target_os = "linux")]
         return Ok(AutoLaunch::new(app_name, app_path, &args));
@@ -355,6 +369,7 @@ impl AutoLaunchBuilder {
             app_name,
             app_path,
             self.use_launch_agent,
+            agent_extra_config,
             &args,
         ));
         #[cfg(target_os = "windows")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,7 @@ pub struct AutoLaunch {
     pub(crate) args: Vec<String>,
 
     #[cfg(target_os = "macos")]
+    /// Bundle identifiers
     pub(crate) bundle_identifiers: Vec<String>,
 
     #[cfg(target_os = "macos")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,9 +282,9 @@ pub struct AutoLaunchBuilder {
 
     pub app_path: Option<String>,
 
-    pub bundle_identifiers: Option<Vec<String>>,
-
     pub use_launch_agent: bool,
+
+    pub bundle_identifiers: Option<Vec<String>>,
 
     pub agent_extra_config: Option<String>,
 

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -10,6 +10,7 @@ impl AutoLaunch {
     /// - `app_name`: application name
     /// - `app_path`: application path
     /// - `use_launch_agent`: whether use Launch Agent or AppleScript
+    /// - `agent_extra_config`: extra config for Launch Agent
     /// - `args`: startup args passed to the binary
     ///
     /// ## Notes
@@ -28,6 +29,7 @@ impl AutoLaunch {
         app_name: &str,
         app_path: &str,
         use_launch_agent: bool,
+        agent_extra_config: &str,
         args: &[impl AsRef<str>],
     ) -> AutoLaunch {
         let mut name = app_name;
@@ -47,6 +49,7 @@ impl AutoLaunch {
             app_name: name.into(),
             app_path: app_path.into(),
             use_launch_agent,
+            agent_extra_config: agent_extra_config.into(),
             args: args.iter().map(|s| s.as_ref().to_string()).collect(),
         }
     }
@@ -102,12 +105,14 @@ impl AutoLaunch {
                 <array>{}</array>\n  \
                 <key>RunAtLoad</key>\n  \
                 <true/>\n  \
+                {}\n  \
             </dict>\n\
             </plist>",
                 r#"<?xml version="1.0" encoding="UTF-8"?>"#,
                 r#"<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">"#,
                 self.app_name,
-                section
+                section,
+                self.agent_extra_config
             );
             fs::File::create(self.get_file())?.write(data.as_bytes())?;
         } else {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -10,8 +10,9 @@ impl AutoLaunch {
     /// - `app_name`: application name
     /// - `app_path`: application path
     /// - `use_launch_agent`: whether use Launch Agent or AppleScript
-    /// - `agent_extra_config`: extra config for Launch Agent
     /// - `args`: startup args passed to the binary
+    /// - `bundle_identifiers`: bundle identifiers
+    /// - `agent_extra_config`: extra config for Launch Agent
     ///
     /// ## Notes
     ///
@@ -29,8 +30,9 @@ impl AutoLaunch {
         app_name: &str,
         app_path: &str,
         use_launch_agent: bool,
-        agent_extra_config: &str,
         args: &[impl AsRef<str>],
+        bundle_identifiers: &[impl AsRef<str>],
+        agent_extra_config: &str,
     ) -> AutoLaunch {
         let mut name = app_name;
         if !use_launch_agent {
@@ -49,8 +51,12 @@ impl AutoLaunch {
             app_name: name.into(),
             app_path: app_path.into(),
             use_launch_agent,
-            agent_extra_config: agent_extra_config.into(),
             args: args.iter().map(|s| s.as_ref().to_string()).collect(),
+            bundle_identifiers: bundle_identifiers
+                .iter()
+                .map(|s| s.as_ref().to_string())
+                .collect(),
+            agent_extra_config: agent_extra_config.into(),
         }
     }
 
@@ -95,24 +101,39 @@ impl AutoLaunch {
                 .map(|x| format!("<string>{}</string>", x))
                 .collect::<String>();
 
+            let identifiers = self
+                .bundle_identifiers
+                .iter()
+                .map(|x| format!("<string>{}</string>", x))
+                .collect::<String>();
+
+            let extra_config = if self.agent_extra_config.len() > 0 {
+                format!("{}\n  ", self.agent_extra_config)
+            } else {
+                "".to_string()
+            };
+
             let data = format!(
                 "{}\n{}\n\
             <plist version=\"1.0\">\n  \
             <dict>\n  \
                 <key>Label</key>\n  \
                 <string>{}</string>\n  \
+                <key>AssociatedBundleIdentifiers</key>\n  \
+                <array>{}</array>\n  \
                 <key>ProgramArguments</key>\n  \
                 <array>{}</array>\n  \
                 <key>RunAtLoad</key>\n  \
                 <true/>\n  \
-                {}\n  \
+                {}\
             </dict>\n\
             </plist>",
                 r#"<?xml version="1.0" encoding="UTF-8"?>"#,
                 r#"<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">"#,
                 self.app_name,
+                identifiers,
                 section,
-                self.agent_extra_config
+                extra_config
             );
             fs::File::create(self.get_file())?.write(data.as_bytes())?;
         } else {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -191,16 +191,17 @@ mod macos_unit_test {
         let name_1 = "AutoLaunchTest"; // different name
         let name_2 = "auto-launch-test"; // same name
 
+        let bundle_identifiers = &["com.github.auto-launch-test"];
         let args = &["--minimized", "--hidden"];
         let app_path = get_test_bin("auto-launch-test");
         let app_path = app_path.as_str();
 
         // applescript
-        let auto1 = AutoLaunch::new(name_1, app_path, false, args);
-        let auto2 = AutoLaunch::new(name_2, app_path, false, args);
+        let auto1 = AutoLaunch::new(name_1, app_path, false, args, bundle_identifiers, "");
+        let auto2 = AutoLaunch::new(name_2, app_path, false, args, bundle_identifiers, "");
         // launch agent
-        let auto3 = AutoLaunch::new(name_1, app_path, true, args);
-        let auto4 = AutoLaunch::new(name_2, app_path, true, args);
+        let auto3 = AutoLaunch::new(name_1, app_path, true, args, bundle_identifiers, "");
+        let auto4 = AutoLaunch::new(name_2, app_path, true, args, bundle_identifiers, "");
 
         // app_name will be revised
         assert_eq!(auto1.get_app_name(), name_2);
@@ -214,6 +215,7 @@ mod macos_unit_test {
     fn test_macos_main() {
         let app_name = "auto-launch-test";
         let app_path = get_test_bin("auto-launch-test");
+        let bundle_identifiers = &["com.github.auto-launch-test"];
         let args = &["--minimized", "--hidden"];
         let app_path = app_path.as_str();
 
@@ -222,27 +224,34 @@ mod macos_unit_test {
         let app_path_not = "/Applications/Calculator1.app";
 
         // use applescript
-        let auto1 = AutoLaunch::new(app_name, app_path, false, args);
+        let auto1 = AutoLaunch::new(app_name, app_path, false, args, bundle_identifiers, "");
         assert_eq!(auto1.get_app_name(), app_name);
         auto1.enable().unwrap();
         assert!(auto1.is_enabled().unwrap());
         auto1.disable().unwrap();
         assert!(!auto1.is_enabled().unwrap());
 
-        let auto2 = AutoLaunch::new(app_name_not, app_path_not, false, args);
+        let auto2 = AutoLaunch::new(
+            app_name_not,
+            app_path_not,
+            false,
+            args,
+            bundle_identifiers,
+            "",
+        );
         assert_eq!(auto2.get_app_name(), app_name_not);
         assert!(auto2.enable().is_err());
         assert!(!auto2.is_enabled().unwrap());
 
         // use launch agent
-        let auto1 = AutoLaunch::new(app_name, app_path, true, args);
+        let auto1 = AutoLaunch::new(app_name, app_path, true, args, bundle_identifiers, "");
         assert_eq!(auto1.get_app_name(), app_name);
         auto1.enable().unwrap();
         assert!(auto1.is_enabled().unwrap());
         auto1.disable().unwrap();
         assert!(!auto1.is_enabled().unwrap());
 
-        let auto2 = AutoLaunch::new(app_name, app_path_not, true, args);
+        let auto2 = AutoLaunch::new(app_name, app_path_not, true, args, bundle_identifiers, "");
         assert_eq!(auto2.get_app_name(), app_name); // will not change the name
         assert!(auto2.enable().is_err());
         assert!(!auto2.is_enabled().unwrap());
@@ -269,6 +278,8 @@ mod macos_unit_test {
             .set_app_path(app_path)
             .set_use_launch_agent(true)
             .set_args(args)
+            .set_bundle_identifiers(bundle_identifiers)
+            .set_agent_extra_config("")
             .build()
             .unwrap();
 


### PR DESCRIPTION
[clash-verge-rev#1420](https://github.com/clash-verge-rev/clash-verge-rev/issues/1420)

# References
- [Updating helper executables from earlier versions of macOS](https://developer.apple.com/documentation/servicemanagement/updating-helper-executables-from-earlier-versions-of-macos#Connect-services-to-app-names-in-System-Settings)