### PR TITLE
feat!: add `systemd` launch mode for linux, and refactor argument passing for launching modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ fn main() {
     let auto = AutoLaunchBuilder::new()
         .set_app_name("the-app")
         .set_app_path("/path/to/the-app")
-        .set_use_launch_agent(true)
+        .set_macos_launch_mode(MacOSLaunchMode::LaunchAgent)
         .build()
         .unwrap();
 
@@ -38,13 +38,22 @@ fn main() {
 
 ### Linux
 
+Linux supports two ways to achieve auto launch:
+- **XDG Autostart**: Uses `.desktop` files in `~/.config/autostart/` (default)
+- **systemd**: Uses systemd user services in `~/.config/systemd/user/`
+
 ```rust
-use auto_launch::AutoLaunch;
+use auto_launch::{AutoLaunch, LinuxLaunchMode};
 
 fn main() {
     let app_name = "the-app";
     let app_path = "/path/to/the-app";
-    let auto = AutoLaunch::new(app_name, app_path, &[] as &[&str]);
+    
+    // Use XDG Autostart (default method)
+    let auto = AutoLaunch::new(app_name, app_path, LinuxLaunchMode::XdgAutostart, &[] as &[&str]);
+    
+    // Or use systemd user service
+    // let auto = AutoLaunch::new(app_name, app_path, LinuxLaunchMode::Systemd, &[] as &[&str]);
 
     // enable the auto launch
     auto.enable().is_ok();
@@ -58,8 +67,9 @@ fn main() {
 
 ### macOS
 
-macOS supports two ways to achieve auto launch (via AppleScript or Launch Agent).
-When the `use_launch_agent` is true, it will achieve by Launch Agent, otherwise by AppleScript.
+macOS supports two ways to achieve auto launch:
+- **Launch Agent**: Uses plist files in `~/Library/LaunchAgents/` (default)
+- **AppleScript**: Uses AppleScript to add login items
 
 **Note**:
 
@@ -68,12 +78,17 @@ When the `use_launch_agent` is true, it will achieve by Launch Agent, otherwise 
 - In case using AppleScript, only `--hidden` and `--minimized` in `args` are valid, which means that hide the app on launch.
 
 ```rust
-use auto_launch::AutoLaunch;
+use auto_launch::{AutoLaunch, MacOSLaunchMode};
 
 fn main() {
     let app_name = "the-app";
     let app_path = "/path/to/the-app.app";
-    let auto = AutoLaunch::new(app_name, app_path, false, &[] as &[&str]);
+    
+    // Use Launch Agent (default method)
+    let auto = AutoLaunch::new(app_name, app_path, MacOSLaunchMode::LaunchAgent, &[] as &[&str], &[] as &[&str], "");
+    
+    // Or use AppleScript
+    // let auto = AutoLaunch::new(app_name, app_path, MacOSLaunchMode::AppleScript, &[] as &[&str], &[] as &[&str], "");
 
     // enable the auto launch
     auto.enable().is_ok();

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,25 @@
+[tasks.test]
+depends = ["build", "build-exe"]
+run = "cargo test"
+
+[tasks.ci]
+depends = ["lint", "test"]
+
+[tasks.lint]
+run = [
+  "cargo fmt --check",
+  "cargo clippy --all-targets --all-features -- -D warnings",
+]
+
+[tasks.lint-fix]
+run = [
+  "cargo fmt --all",
+  "cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features --allow-no-vcs -- -D warnings",
+]
+
+[tasks.build]
+run = "cargo build"
+
+[tasks.build-exe]
+run = "cargo build --release"
+dir = "test-exe"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,13 +10,14 @@
 //! ```rust
 //! # #[cfg(target_os = "linux")]
 //! # mod linux {
-//! use auto_launch::AutoLaunch;
+//! use auto_launch::{AutoLaunch, LinuxLaunchMode};
 //!
 //! fn main() {
 //!     let app_name = "the-app";
 //!     let app_path = "/path/to/the-app";
 //!     let args = &["--minimized"];
-//!     let auto = AutoLaunch::new(app_name, app_path, args);
+//!     // Use XDG Autostart by default, or use LinuxLaunchMode::Systemd for systemd
+//!     let auto = AutoLaunch::new(app_name, app_path, LinuxLaunchMode::XdgAutostart, args);
 //!
 //!     // enable the auto launch
 //!     auto.enable().is_ok();
@@ -31,24 +32,27 @@
 //!
 //! ### macOS
 //!
-//! macOS supports two ways to achieve auto launch (via AppleScript or Launch Agent).
-//! When the `use_launch_agent` is true, it will achieve by Launch Agent, otherwise by AppleScript.
+//! macOS supports two ways to achieve auto launch:
+//! - **Launch Agent**: Uses plist files in `~/Library/LaunchAgents/` (default)
+//! - **AppleScript**: Uses AppleScript to add login items
 //!
 //! **Note**:
 //! - The `app_path` should be a absolute path and exists. Otherwise, it will cause an error when `enable`.
 //! - In case using AppleScript, the `app_name` should be same as the basename of `app_path`, or it will be corrected automatically.
+//! - In case using AppleScript, only `--hidden` and `--minimized` in `args` are valid, which means that hide the app on launch.
 //!
 //! ```rust
 //! # #[cfg(target_os = "macos")]
 //! # mod macos {
-//! use auto_launch::AutoLaunch;
+//! use auto_launch::{AutoLaunch, MacOSLaunchMode};
 //!
 //! fn main() {
 //!     let app_name = "the-app";
 //!     let app_path = "/path/to/the-app.app";
 //!     let args = &["--minimized"];
 //!     let bundle_identifiers = &["com.github.auto-launch-test"];
-//!     let auto = AutoLaunch::new(app_name, app_path, false, args, bundle_identifiers, "");
+//!     // Use Launch Agent by default, or use MacOSLaunchMode::AppleScript
+//!     let auto = AutoLaunch::new(app_name, app_path, MacOSLaunchMode::LaunchAgent, args, bundle_identifiers, "");
 //!
 //!     // enable the auto launch
 //!     auto.enable().is_ok();
@@ -68,7 +72,7 @@
 //!
 //! By default we try to apply the auto launch to the system registry, which requires admin privileges and applies the auto launch to any user in the system.
 //! If there's no permission to do so, we fallback to enabling it to the current user only.
-//! To change this behavior, you can use [`AutoLaunch::set_windows_enable_mode`].
+//! To change this behavior, specify the [`WindowsEnableMode`] when creating the [`AutoLaunch`] instance.
 //!
 //! ```rust
 //! # #[cfg(target_os = "windows")]
@@ -101,21 +105,21 @@
 //! ```rust
 //! use auto_launch::*;
 //!
-//! fn main() {
-//!     let auto = AutoLaunchBuilder::new()
-//!         .set_app_name("the-app")
-//!         .set_app_path("/path/to/the-app")
-//!         .set_use_launch_agent(true)
-//!         .set_args(&["--minimized"])
-//!         .build()
-//!         .unwrap();
+//! # fn example() -> std::result::Result<(), Box<dyn std::error::Error>> {
+//! let auto = AutoLaunchBuilder::new()
+//!     .set_app_name("the-app")
+//!     .set_app_path("/path/to/the-app")
+//!     .set_macos_launch_mode(MacOSLaunchMode::LaunchAgent)
+//!     .set_args(&["--minimized"])
+//!     .build()?;
 //!
-//!     auto.enable().is_ok();
-//!     auto.is_enabled().unwrap();
+//! auto.enable()?;
+//! auto.is_enabled()?;
 //!
-//!     auto.disable().is_ok();
-//!     auto.is_enabled().unwrap();
-//! }
+//! auto.disable()?;
+//! auto.is_enabled()?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 
@@ -153,11 +157,12 @@ mod windows;
 /// ```rust
 /// # #[cfg(target_os = "linux")]
 /// # {
-/// # use auto_launch::AutoLaunch;
+/// # use auto_launch::{AutoLaunch, LinuxLaunchMode};
 /// # let app_name = "the-app";
 /// # let app_path = "/path/to/the-app";
+/// # let launch_mode = LinuxLaunchMode::XdgAutostart;
 /// # let args = &["--minimized"];
-/// AutoLaunch::new(app_name, app_path, args);
+/// AutoLaunch::new(app_name, app_path, launch_mode, args);
 /// # }
 /// ```
 ///
@@ -166,13 +171,13 @@ mod windows;
 /// ```rust
 /// # #[cfg(target_os = "macos")]
 /// # {
-/// # use auto_launch::AutoLaunch;
+/// # use auto_launch::{AutoLaunch, MacOSLaunchMode};
 /// # let app_name = "the-app";
 /// # let app_path = "/path/to/the-app";
-/// # let use_launch_agent = false;
+/// # let launch_mode = MacOSLaunchMode::LaunchAgent;
 /// # let args = &["--minimized"];
 /// # let bundle_identifiers = &["com.github.auto-launch-test"];
-/// AutoLaunch::new(app_name, app_path, use_launch_agent, args, bundle_identifiers, "");
+/// AutoLaunch::new(app_name, app_path, launch_mode, args, bundle_identifiers, "");
 /// # }
 /// ```
 ///
@@ -200,9 +205,13 @@ pub struct AutoLaunch {
     /// Args passed to the binary on startup
     pub(crate) args: Vec<String>,
 
+    #[cfg(target_os = "linux")]
+    /// Launch mode for Linux (XDG Autostart or systemd)
+    pub(crate) launch_mode: LinuxLaunchMode,
+
     #[cfg(target_os = "macos")]
-    /// Whether use Launch Agent for implement or use AppleScript
-    pub(crate) use_launch_agent: bool,
+    /// Launch mode for macOS (Launch Agent or AppleScript)
+    pub(crate) launch_mode: MacOSLaunchMode,
 
     #[cfg(target_os = "macos")]
     /// Bundle identifiers
@@ -263,28 +272,28 @@ impl AutoLaunch {
 /// ```rust
 /// use auto_launch::*;
 ///
-/// fn main() {
-///     let auto = AutoLaunchBuilder::new()
-///         .set_app_name("the-app")
-///         .set_app_path("/path/to/the-app")
-///         .set_use_launch_agent(true)
-///         .set_args(&["--minimized"])
-///         .build()
-///         .unwrap();
+/// # fn example() -> std::result::Result<(), Box<dyn std::error::Error>> {
+/// let auto = AutoLaunchBuilder::new()
+///     .set_app_name("the-app")
+///     .set_app_path("/path/to/the-app")
+///     .set_macos_launch_mode(MacOSLaunchMode::LaunchAgent)
+///     .set_args(&["--minimized"])
+///     .build()?;
 ///
-///     auto.enable().is_ok();
-///     auto.is_enabled().unwrap();
+/// auto.enable()?;
+/// auto.is_enabled()?;
 ///
-///     auto.disable().is_ok();
-///     auto.is_enabled().unwrap();
-/// }
+/// auto.disable()?;
+/// auto.is_enabled()?;
+/// # Ok(())
+/// # }
 /// ```
 pub struct AutoLaunchBuilder {
     pub app_name: Option<String>,
 
     pub app_path: Option<String>,
 
-    pub use_launch_agent: bool,
+    pub macos_launch_mode: MacOSLaunchMode,
 
     pub bundle_identifiers: Option<Vec<String>>,
 
@@ -292,7 +301,39 @@ pub struct AutoLaunchBuilder {
 
     pub windows_enable_mode: WindowsEnableMode,
 
+    pub linux_launch_mode: LinuxLaunchMode,
+
     pub args: Option<Vec<String>>,
+}
+
+/// Determines how the auto launch is enabled on Linux.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LinuxLaunchMode {
+    /// Use XDG Autostart (.desktop file in ~/.config/autostart/)
+    XdgAutostart,
+    /// Use systemd user service (~/.config/systemd/user/)
+    Systemd,
+}
+
+impl Default for LinuxLaunchMode {
+    fn default() -> Self {
+        Self::XdgAutostart
+    }
+}
+
+/// Determines how the auto launch is enabled on macOS.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MacOSLaunchMode {
+    /// Use Launch Agent (plist file in ~/Library/LaunchAgents/)
+    LaunchAgent,
+    /// Use AppleScript to add login item
+    AppleScript,
+}
+
+impl Default for MacOSLaunchMode {
+    fn default() -> Self {
+        Self::LaunchAgent
+    }
 }
 
 /// Determines how the auto launch is enabled on Windows.
@@ -330,10 +371,22 @@ impl AutoLaunchBuilder {
         self
     }
 
-    /// Set the `use_launch_agent`
+    /// Set the [`MacOSLaunchMode`].
     /// This setting only works on macOS
+    pub fn set_macos_launch_mode(&mut self, mode: MacOSLaunchMode) -> &mut Self {
+        self.macos_launch_mode = mode;
+        self
+    }
+
+    /// Set the `use_launch_agent` (deprecated: use `set_macos_launch_mode` instead)
+    /// This setting only works on macOS
+    #[deprecated(since = "0.6.0", note = "Use `set_macos_launch_mode` instead")]
     pub fn set_use_launch_agent(&mut self, use_launch_agent: bool) -> &mut Self {
-        self.use_launch_agent = use_launch_agent;
+        self.macos_launch_mode = if use_launch_agent {
+            MacOSLaunchMode::LaunchAgent
+        } else {
+            MacOSLaunchMode::AppleScript
+        };
         self
     }
 
@@ -363,6 +416,13 @@ impl AutoLaunchBuilder {
         self
     }
 
+    /// Set the [`LinuxLaunchMode`].
+    /// This setting only works on Linux
+    pub fn set_linux_launch_mode(&mut self, mode: LinuxLaunchMode) -> &mut Self {
+        self.linux_launch_mode = mode;
+        self
+    }
+
     /// Set the args
     pub fn set_args(&mut self, args: &[impl AsRef<str>]) -> &mut Self {
         self.args = Some(args.iter().map(|s| s.as_ref().to_string()).collect());
@@ -384,12 +444,17 @@ impl AutoLaunchBuilder {
         let agent_extra_config = self.agent_extra_config.as_ref().map_or("", |v| v);
 
         #[cfg(target_os = "linux")]
-        return Ok(AutoLaunch::new(app_name, app_path, &args));
+        return Ok(AutoLaunch::new(
+            app_name,
+            app_path,
+            self.linux_launch_mode,
+            &args,
+        ));
         #[cfg(target_os = "macos")]
         return Ok(AutoLaunch::new(
             app_name,
             app_path,
-            self.use_launch_agent,
+            self.macos_launch_mode,
             &args,
             &bundle_identifiers,
             agent_extra_config,

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -1,4 +1,4 @@
-use crate::{AutoLaunch, Result};
+use crate::{AutoLaunch, LinuxLaunchMode, Result};
 use std::{fs, io::Write, path::PathBuf};
 
 /// Linux implement
@@ -6,15 +6,22 @@ impl AutoLaunch {
     /// Create a new AutoLaunch instance
     /// - `app_name`: application name
     /// - `app_path`: application path
+    /// - `launch_mode`: launch mode (XDG Autostart or systemd)
     /// - `args`: startup args passed to the binary
     ///
     /// ## Notes
     ///
     /// The parameters of `AutoLaunch::new` are different on each platform.
-    pub fn new(app_name: &str, app_path: &str, args: &[impl AsRef<str>]) -> AutoLaunch {
+    pub fn new(
+        app_name: &str,
+        app_path: &str,
+        launch_mode: LinuxLaunchMode,
+        args: &[impl AsRef<str>],
+    ) -> AutoLaunch {
         AutoLaunch {
             app_name: app_name.into(),
             app_path: app_path.into(),
+            launch_mode,
             args: args.iter().map(|s| s.as_ref().to_string()).collect(),
         }
     }
@@ -23,16 +30,25 @@ impl AutoLaunch {
     ///
     /// ## Errors
     ///
-    /// - failed to create dir `~/.config/autostart`
-    /// - failed to create file `~/.config/autostart/{app_name}.desktop`
+    /// - failed to create directory
+    /// - failed to create file
     /// - failed to write bytes to the file
+    /// - failed to enable systemd service (if using systemd mode)
     pub fn enable(&self) -> Result<()> {
+        match self.launch_mode {
+            LinuxLaunchMode::XdgAutostart => self.enable_xdg_autostart(),
+            LinuxLaunchMode::Systemd => self.enable_systemd(),
+        }
+    }
+
+    /// Enable using XDG Autostart (.desktop file)
+    fn enable_xdg_autostart(&self) -> Result<()> {
         let data = format!(
             "[Desktop Entry]\n\
             Type=Application\n\
             Version=1.0\n\
             Name={}\n\
-            Comment={}startup script\n\
+            Comment={} startup script\n\
             Exec={} {}\n\
             StartupNotify=false\n\
             Terminal=false",
@@ -42,7 +58,7 @@ impl AutoLaunch {
             self.args.join(" ")
         );
 
-        let dir = get_dir();
+        let dir = get_xdg_autostart_dir();
         if !dir.exists() {
             fs::create_dir_all(&dir).or_else(|e| {
                 if e.kind() == std::io::ErrorKind::AlreadyExists {
@@ -52,12 +68,86 @@ impl AutoLaunch {
                 }
             })?;
         }
+        let file_path = self.get_xdg_desktop_file();
         let mut file = fs::OpenOptions::new()
             .write(true)
             .create(true)
             .truncate(true)
-            .open(self.get_file())?;
+            .open(file_path)?;
         file.write_all(data.as_bytes())?;
+        Ok(())
+    }
+
+    /// Enable using systemd user service
+    fn enable_systemd(&self) -> Result<()> {
+        // Create systemd service file content
+        let args_str = if self.args.is_empty() {
+            String::new()
+        } else {
+            format!(" {}", self.args.join(" "))
+        };
+
+        let data = format!(
+            "[Unit]\n\
+            Description={}\n\
+            After=default.target\n\
+            \n\
+            [Service]\n\
+            Type=simple\n\
+            ExecStart={}{}\n\
+            Restart=on-failure\n\
+            RestartSec=10\n\
+            \n\
+            [Install]\n\
+            WantedBy=default.target",
+            self.app_name, self.app_path, args_str
+        );
+
+        // Create systemd user directory
+        let dir = get_systemd_user_dir();
+        if !dir.exists() {
+            fs::create_dir_all(&dir).or_else(|e| {
+                if e.kind() == std::io::ErrorKind::AlreadyExists {
+                    Ok(())
+                } else {
+                    Err(e)
+                }
+            })?;
+        }
+
+        // Write service file
+        let service_file = self.get_systemd_service_file();
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&service_file)?;
+        file.write_all(data.as_bytes())?;
+
+        // Enable and start the service using systemctl
+        self.systemctl_enable()?;
+
+        Ok(())
+    }
+
+    /// Run systemctl --user enable command
+    fn systemctl_enable(&self) -> Result<()> {
+        let service_name = format!("{}.service", self.app_name);
+        let output = std::process::Command::new("systemctl")
+            .args(&["--user", "enable", &service_name])
+            .output()?;
+
+        if !output.status.success() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!(
+                    "Failed to enable systemd service: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                ),
+            )
+            .into());
+        }
+
         Ok(())
     }
 
@@ -65,27 +155,108 @@ impl AutoLaunch {
     ///
     /// ## Errors
     ///
-    /// - failed to remove file `~/.config/autostart/{app_name}.desktop`
+    /// - failed to remove file
+    /// - failed to disable systemd service (if using systemd mode)
     pub fn disable(&self) -> Result<()> {
-        let file = self.get_file();
+        match self.launch_mode {
+            LinuxLaunchMode::XdgAutostart => self.disable_xdg_autostart(),
+            LinuxLaunchMode::Systemd => self.disable_systemd(),
+        }
+    }
+
+    /// Disable XDG Autostart
+    fn disable_xdg_autostart(&self) -> Result<()> {
+        let file = self.get_xdg_desktop_file();
         if file.exists() {
             fs::remove_file(file)?;
         }
         Ok(())
     }
 
-    /// Check whether the AutoLaunch setting is enabled
-    pub fn is_enabled(&self) -> Result<bool> {
-        Ok(self.get_file().exists())
+    /// Disable systemd user service
+    fn disable_systemd(&self) -> Result<()> {
+        // Disable the service
+        self.systemctl_disable()?;
+
+        // Remove service file
+        let service_file = self.get_systemd_service_file();
+        if service_file.exists() {
+            fs::remove_file(service_file)?;
+        }
+
+        // Reload systemd daemon
+        let _ = std::process::Command::new("systemctl")
+            .args(&["--user", "daemon-reload"])
+            .output();
+
+        Ok(())
     }
 
-    /// Get the desktop entry file path
-    fn get_file(&self) -> PathBuf {
-        get_dir().join(format!("{}.desktop", self.app_name))
+    /// Run systemctl --user disable command
+    fn systemctl_disable(&self) -> Result<()> {
+        let service_name = format!("{}.service", self.app_name);
+        let output = std::process::Command::new("systemctl")
+            .args(&["--user", "disable", &service_name])
+            .output()?;
+
+        // Don't fail if the service is not enabled
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if !stderr.contains("No such file or directory") && !stderr.contains("not loaded") {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Failed to disable systemd service: {}", stderr),
+                )
+                .into());
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Check whether the AutoLaunch setting is enabled
+    pub fn is_enabled(&self) -> Result<bool> {
+        match self.launch_mode {
+            LinuxLaunchMode::XdgAutostart => Ok(self.get_xdg_desktop_file().exists()),
+            LinuxLaunchMode::Systemd => self.is_systemd_enabled(),
+        }
+    }
+
+    /// Check if systemd service is enabled
+    fn is_systemd_enabled(&self) -> Result<bool> {
+        let service_name = format!("{}.service", self.app_name);
+        let output = std::process::Command::new("systemctl")
+            .args(&["--user", "is-enabled", &service_name])
+            .output()?;
+
+        // systemctl is-enabled returns:
+        // - "enabled" with exit code 0 if enabled
+        // - "disabled" with exit code 1 if disabled
+        // - other states or errors with other exit codes
+        Ok(output.status.success())
+    }
+
+    /// Get the XDG desktop entry file path
+    fn get_xdg_desktop_file(&self) -> PathBuf {
+        get_xdg_autostart_dir().join(format!("{}.desktop", self.app_name))
+    }
+
+    /// Get the systemd service file path
+    fn get_systemd_service_file(&self) -> PathBuf {
+        get_systemd_user_dir().join(format!("{}.service", self.app_name))
     }
 }
 
-/// Get the autostart dir
-fn get_dir() -> PathBuf {
+/// Get the XDG autostart directory
+fn get_xdg_autostart_dir() -> PathBuf {
     dirs::home_dir().unwrap().join(".config").join("autostart")
+}
+
+/// Get the systemd user service directory
+fn get_systemd_user_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap()
+        .join(".config")
+        .join("systemd")
+        .join("user")
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,15 +1,17 @@
-use crate::{AutoLaunch, Error, Result};
-use std::fs;
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+use crate::{AutoLaunch, Error, MacOSLaunchMode, Result};
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
 
 /// macOS implement
 impl AutoLaunch {
     /// Create a new AutoLaunch instance
     /// - `app_name`: application name
     /// - `app_path`: application path
-    /// - `use_launch_agent`: whether use Launch Agent or AppleScript
+    /// - `launch_mode`: launch mode (Launch Agent or AppleScript)
     /// - `args`: startup args passed to the binary
     /// - `bundle_identifiers`: bundle identifiers
     /// - `agent_extra_config`: extra config for Launch Agent
@@ -19,23 +21,23 @@ impl AutoLaunch {
     /// The parameters of `AutoLaunch::new` are different on each platform.
     ///
     /// The `app_name` should be same as the basename of the `app_path`
-    ///     when `use_launch_agent` is false, or it will be corrected automatically.
+    ///     when using AppleScript mode, or it will be corrected automatically.
     ///
     /// The `app_path` should be the **absolute path** and **exists**,
     ///     otherwise it will cause an error when `enable`.
     ///
-    /// In case using AppleScript (`use_launch_agent=false`),
+    /// In case using AppleScript,
     ///     only `"--hidden"` and `"--minimized"` in `args` are valid.
     pub fn new(
         app_name: &str,
         app_path: &str,
-        use_launch_agent: bool,
+        launch_mode: MacOSLaunchMode,
         args: &[impl AsRef<str>],
         bundle_identifiers: &[impl AsRef<str>],
         agent_extra_config: &str,
     ) -> AutoLaunch {
         let mut name = app_name;
-        if !use_launch_agent {
+        if launch_mode == MacOSLaunchMode::AppleScript {
             // the app_name should be same as the executable's name
             // when using login item
             let end = if app_path.ends_with(".app") { 4 } else { 0 };
@@ -50,7 +52,7 @@ impl AutoLaunch {
         AutoLaunch {
             app_name: name.into(),
             app_path: app_path.into(),
-            use_launch_agent,
+            launch_mode,
             args: args.iter().map(|s| s.as_ref().to_string()).collect(),
             bundle_identifiers: bundle_identifiers
                 .iter()
@@ -87,72 +89,82 @@ impl AutoLaunch {
             return Err(Error::AppPathIsNotAbsolute(path.to_path_buf()));
         }
 
-        if self.use_launch_agent {
-            let dir = get_dir();
-            if !dir.exists() {
-                fs::create_dir(&dir)?;
-            }
+        match self.launch_mode {
+            MacOSLaunchMode::LaunchAgent => self.enable_launch_agent(),
+            MacOSLaunchMode::AppleScript => self.enable_applescript(),
+        }
+    }
 
-            let mut args = vec![self.app_path.clone()];
-            args.extend_from_slice(&self.args);
+    /// Enable using Launch Agent
+    fn enable_launch_agent(&self) -> Result<()> {
+        let dir = get_dir();
+        if !dir.exists() {
+            fs::create_dir(&dir)?;
+        }
 
-            let section = args
-                .iter()
-                .map(|x| format!("<string>{}</string>", x))
-                .collect::<String>();
+        let mut args = vec![self.app_path.clone()];
+        args.extend_from_slice(&self.args);
 
-            let identifiers = self
-                .bundle_identifiers
-                .iter()
-                .map(|x| format!("<string>{}</string>", x))
-                .collect::<String>();
+        let section = args
+            .iter()
+            .map(|x| format!("<string>{}</string>", x))
+            .collect::<String>();
 
-            let extra_config = if self.agent_extra_config.len() > 0 {
-                format!("{}\n  ", self.agent_extra_config)
-            } else {
-                "".to_string()
-            };
+        let identifiers = self
+            .bundle_identifiers
+            .iter()
+            .map(|x| format!("<string>{}</string>", x))
+            .collect::<String>();
 
-            let data = format!(
-                "{}\n{}\n\
-            <plist version=\"1.0\">\n  \
-            <dict>\n  \
-                <key>Label</key>\n  \
-                <string>{}</string>\n  \
-                <key>AssociatedBundleIdentifiers</key>\n  \
-                <array>{}</array>\n  \
-                <key>ProgramArguments</key>\n  \
-                <array>{}</array>\n  \
-                <key>RunAtLoad</key>\n  \
-                <true/>\n  \
-                {}\
-            </dict>\n\
-            </plist>",
-                r#"<?xml version="1.0" encoding="UTF-8"?>"#,
-                r#"<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">"#,
-                self.app_name,
-                identifiers,
-                section,
-                extra_config
-            );
-            fs::File::create(self.get_file())?.write(data.as_bytes())?;
+        let extra_config = if !self.agent_extra_config.is_empty() {
+            format!("{}\n  ", self.agent_extra_config)
         } else {
-            let hidden = self
-                .args
-                .iter()
-                .find(|arg| *arg == "--hidden" || *arg == "--minimized");
+            "".to_string()
+        };
 
-            let props = format!(
-                "{{name:\"{}\",path:\"{}\",hidden:{}}}",
-                self.app_name,
-                self.app_path,
-                hidden.is_some()
-            );
-            let command = format!("make login item at end with properties {}", props);
-            let output = exec_apple_script(&command)?;
-            if !output.status.success() {
-                return Err(Error::AppleScriptFailed(output.status.code().unwrap_or(1)));
-            }
+        let data = format!(
+            "{}\n{}\n\
+        <plist version=\"1.0\">\n  \
+        <dict>\n  \
+            <key>Label</key>\n  \
+            <string>{}</string>\n  \
+            <key>AssociatedBundleIdentifiers</key>\n  \
+            <array>{}</array>\n  \
+            <key>ProgramArguments</key>\n  \
+            <array>{}</array>\n  \
+            <key>RunAtLoad</key>\n  \
+            <true/>\n  \
+            {}\
+        </dict>\n\
+        </plist>",
+            r#"<?xml version="1.0" encoding="UTF-8"?>"#,
+            r#"<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">"#,
+            self.app_name,
+            identifiers,
+            section,
+            extra_config
+        );
+        let _ = fs::File::create(self.get_file())?.write(data.as_bytes())?;
+        Ok(())
+    }
+
+    /// Enable using AppleScript
+    fn enable_applescript(&self) -> Result<()> {
+        let hidden = self
+            .args
+            .iter()
+            .find(|arg| *arg == "--hidden" || *arg == "--minimized");
+
+        let props = format!(
+            "{{name:\"{}\",path:\"{}\",hidden:{}}}",
+            self.app_name,
+            self.app_path,
+            hidden.is_some()
+        );
+        let command = format!("make login item at end with properties {}", props);
+        let output = exec_apple_script(&command)?;
+        if !output.status.success() {
+            return Err(Error::AppleScriptFailed(output.status.code().unwrap_or(1)));
         }
         Ok(())
     }
@@ -169,36 +181,53 @@ impl AutoLaunch {
     ///
     /// - failed to execute the `osascript` command, check the exit status or stderr for details
     pub fn disable(&self) -> Result<()> {
-        if self.use_launch_agent {
-            let file = self.get_file();
-            if file.exists() {
-                fs::remove_file(file)?;
-            }
-        } else {
-            let command = format!("delete login item \"{}\"", self.app_name);
-            let output = exec_apple_script(&command)?;
-            if !output.status.success() {
-                return Err(Error::AppleScriptFailed(output.status.code().unwrap_or(1)));
-            }
+        match self.launch_mode {
+            MacOSLaunchMode::LaunchAgent => self.disable_launch_agent(),
+            MacOSLaunchMode::AppleScript => self.disable_applescript(),
+        }
+    }
+
+    /// Disable Launch Agent
+    fn disable_launch_agent(&self) -> Result<()> {
+        let file = self.get_file();
+        if file.exists() {
+            fs::remove_file(file)?;
+        }
+        Ok(())
+    }
+
+    /// Disable AppleScript login item
+    fn disable_applescript(&self) -> Result<()> {
+        let command = format!("delete login item \"{}\"", self.app_name);
+        let output = exec_apple_script(&command)?;
+        if !output.status.success() {
+            return Err(Error::AppleScriptFailed(output.status.code().unwrap_or(1)));
         }
         Ok(())
     }
 
     /// Check whether the AutoLaunch setting is enabled
     pub fn is_enabled(&self) -> Result<bool> {
-        if self.use_launch_agent {
-            Ok(self.get_file().exists())
-        } else {
-            let command = "get the name of every login item";
-            let output = exec_apple_script(command)?;
-            let mut enable = false;
-            if output.status.success() {
-                let stdout = std::str::from_utf8(&output.stdout).unwrap_or("");
-                let mut stdout = stdout.split(",").map(|x| x.trim());
-                enable = stdout.find(|x| x == &self.app_name).is_some();
-            }
-            Ok(enable)
+        match self.launch_mode {
+            MacOSLaunchMode::LaunchAgent => Ok(self.get_file().exists()),
+            MacOSLaunchMode::AppleScript => self.is_applescript_enabled(),
         }
+    }
+
+    /// Check if AppleScript login item is enabled
+    fn is_applescript_enabled(&self) -> Result<bool> {
+        let command = "get the name of every login item";
+        let output = exec_apple_script(command)?;
+        let enable = if output.status.success() {
+            let stdout = std::str::from_utf8(&output.stdout).unwrap_or("");
+            stdout
+                .split(',')
+                .map(|x| x.trim())
+                .any(|x| x == self.app_name)
+        } else {
+            false
+        };
+        Ok(enable)
     }
 
     /// get the plist file path

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod unit_test {
-    #[cfg(not(target_os = "macos"))]
-    use auto_launch::{AutoLaunch, AutoLaunchBuilder};
     #[cfg(target_os = "macos")]
     use auto_launch::AutoLaunch;
+    #[cfg(not(target_os = "macos"))]
+    use auto_launch::{AutoLaunch, AutoLaunchBuilder};
     use std::env::current_dir;
 
     pub fn get_test_bin(name: &str) -> String {
@@ -191,6 +191,8 @@ mod macos_unit_test {
 
     #[test]
     fn test_macos_new() {
+        use auto_launch::MacOSLaunchMode;
+
         let name_1 = "AutoLaunchTest"; // different name
         let name_2 = "auto-launch-test"; // same name
 
@@ -200,11 +202,39 @@ mod macos_unit_test {
         let app_path = app_path.as_str();
 
         // applescript
-        let auto1 = AutoLaunch::new(name_1, app_path, false, args, bundle_identifiers, "");
-        let auto2 = AutoLaunch::new(name_2, app_path, false, args, bundle_identifiers, "");
+        let auto1 = AutoLaunch::new(
+            name_1,
+            app_path,
+            MacOSLaunchMode::AppleScript,
+            args,
+            bundle_identifiers,
+            "",
+        );
+        let auto2 = AutoLaunch::new(
+            name_2,
+            app_path,
+            MacOSLaunchMode::AppleScript,
+            args,
+            bundle_identifiers,
+            "",
+        );
         // launch agent
-        let auto3 = AutoLaunch::new(name_1, app_path, true, args, bundle_identifiers, "");
-        let auto4 = AutoLaunch::new(name_2, app_path, true, args, bundle_identifiers, "");
+        let auto3 = AutoLaunch::new(
+            name_1,
+            app_path,
+            MacOSLaunchMode::LaunchAgent,
+            args,
+            bundle_identifiers,
+            "",
+        );
+        let auto4 = AutoLaunch::new(
+            name_2,
+            app_path,
+            MacOSLaunchMode::LaunchAgent,
+            args,
+            bundle_identifiers,
+            "",
+        );
 
         // app_name will be revised
         assert_eq!(auto1.get_app_name(), name_2);
@@ -216,6 +246,8 @@ mod macos_unit_test {
 
     #[test]
     fn test_macos_main() {
+        use auto_launch::MacOSLaunchMode;
+
         let app_name = "auto-launch-test";
         let app_path = get_test_bin("auto-launch-test");
         let bundle_identifiers = &["com.github.auto-launch-test"];
@@ -227,7 +259,14 @@ mod macos_unit_test {
         let app_path_not = "/Applications/Calculator1.app";
 
         // use applescript
-        let auto1 = AutoLaunch::new(app_name, app_path, false, args, bundle_identifiers, "");
+        let auto1 = AutoLaunch::new(
+            app_name,
+            app_path,
+            MacOSLaunchMode::AppleScript,
+            args,
+            bundle_identifiers,
+            "",
+        );
         assert_eq!(auto1.get_app_name(), app_name);
         auto1.enable().unwrap();
         assert!(auto1.is_enabled().unwrap());
@@ -237,7 +276,7 @@ mod macos_unit_test {
         let auto2 = AutoLaunch::new(
             app_name_not,
             app_path_not,
-            false,
+            MacOSLaunchMode::AppleScript,
             args,
             bundle_identifiers,
             "",
@@ -247,14 +286,28 @@ mod macos_unit_test {
         assert!(!auto2.is_enabled().unwrap());
 
         // use launch agent
-        let auto1 = AutoLaunch::new(app_name, app_path, true, args, bundle_identifiers, "");
+        let auto1 = AutoLaunch::new(
+            app_name,
+            app_path,
+            MacOSLaunchMode::LaunchAgent,
+            args,
+            bundle_identifiers,
+            "",
+        );
         assert_eq!(auto1.get_app_name(), app_name);
         auto1.enable().unwrap();
         assert!(auto1.is_enabled().unwrap());
         auto1.disable().unwrap();
         assert!(!auto1.is_enabled().unwrap());
 
-        let auto2 = AutoLaunch::new(app_name, app_path_not, true, args, bundle_identifiers, "");
+        let auto2 = AutoLaunch::new(
+            app_name,
+            app_path_not,
+            MacOSLaunchMode::LaunchAgent,
+            args,
+            bundle_identifiers,
+            "",
+        );
         assert_eq!(auto2.get_app_name(), app_name); // will not change the name
         assert!(auto2.enable().is_err());
         assert!(!auto2.is_enabled().unwrap());
@@ -275,11 +328,11 @@ mod macos_unit_test {
         auto.disable().unwrap();
         assert!(!auto.is_enabled().unwrap());
 
-        // use launch agent
+        // use launch agent with new API
         let auto = AutoLaunchBuilder::new()
             .set_app_name(app_name)
             .set_app_path(app_path)
-            .set_use_launch_agent(true)
+            .set_macos_launch_mode(MacOSLaunchMode::LaunchAgent)
             .set_args(args)
             .set_bundle_identifiers(bundle_identifiers)
             .set_agent_extra_config("")
@@ -302,13 +355,15 @@ mod linux_unit_test {
 
     #[test]
     fn test_linux() {
+        use auto_launch::LinuxLaunchMode;
+
         let app_name = "AutoLaunchTest";
         let app_path = get_test_bin("auto-launch-test");
         let args = &["--minimized"];
         let app_path = app_path.as_str();
 
-        // default test
-        let auto1 = AutoLaunch::new(app_name, app_path, args);
+        // test XDG Autostart (default)
+        let auto1 = AutoLaunch::new(app_name, app_path, LinuxLaunchMode::XdgAutostart, args);
 
         assert_eq!(auto1.get_app_name(), app_name);
         auto1.enable().unwrap();
@@ -316,13 +371,15 @@ mod linux_unit_test {
         auto1.disable().unwrap();
         assert!(!auto1.is_enabled().unwrap());
 
-        // test args
-        let auto2 = AutoLaunch::new(app_name, app_path, args);
+        // test systemd mode
+        let auto2 = AutoLaunch::new(app_name, app_path, LinuxLaunchMode::Systemd, args);
 
         assert_eq!(auto2.get_app_name(), app_name);
-        auto2.enable().unwrap();
-        assert!(auto2.is_enabled().unwrap());
-        auto2.disable().unwrap();
-        assert!(!auto2.is_enabled().unwrap());
+        // Note: systemd tests may require systemctl to be available
+        if let Ok(_) = auto2.enable() {
+            assert!(auto2.is_enabled().unwrap());
+            auto2.disable().unwrap();
+            assert!(!auto2.is_enabled().unwrap());
+        }
     }
 }


### PR DESCRIPTION
Now we use enums instead of booleans to pass launch mode for macOS and Linux,  because I want to support more launch modes for Linux, such as crontab.

I add `systemd` launch mode because most of my use cases for rust projects to auto launch are on server instead of desktop environment, 
which means XDG method is not working.

Sorry for bringing a relatively big PR!